### PR TITLE
pass through popperContainer

### DIFF
--- a/addon/templates/components/ember-attacher.hbs
+++ b/addon/templates/components/ember-attacher.hbs
@@ -1,5 +1,6 @@
 {{#ember-popper options=_options
                 popperClass=popperClass
+                popperContainer=popperContainer
                 renderInPlace=renderInPlace
                 target=target as |emberPopper|}}
   {{#ember-attacher-inner animation=animation


### PR DESCRIPTION
Fixes #6 by allowing you to specify a different rootElement where the poppers will be rendered