### PR TITLE
Check whether component is not destroyed inside `next`

### DIFF
--- a/addon/components/ember-attacher-inner.js
+++ b/addon/components/ember-attacher-inner.js
@@ -240,6 +240,10 @@ export default Component.extend({
     // turn on the same time as our show animation, and `display: none` => `display: anythingElse`
     // is not transition-able
     next(this, () => {
+      if (this.isDestroyed || this.isDestroying) {
+        return;
+      }
+
       const showDuration = parseInt(this.get('showDuration'));
 
       this.element.style.transitionDuration = `${showDuration}ms`;


### PR DESCRIPTION
I'm not sure exactly how to reproduce this, but we have multiple ember-attacher instances on a page and getting "TypeError: Cannot read property 'style' of null" error pretty regularly.

I guess it would make sense to check for `isDestroyed` anyway since we're already in a new Run Loop.