### PR TITLE
feat(tagless component) popperClass is now class and id is passed to attachment

### DIFF
--- a/addon/components/ember-attacher.js
+++ b/addon/components/ember-attacher.js
@@ -26,8 +26,14 @@ const DEFAULTS = {
   showOn: 'mouseenter focus'
 };
 
+// TODO(kjb) see if there is a way to only pull generateGuid
+import Ember from 'ember';
+const { generateGuid } = Ember;
+
 export default Component.extend({
   layout,
+
+  tagName: '',
 
   /**
    * ================== PUBLIC CONFIG OPTIONS ==================
@@ -63,19 +69,25 @@ export default Component.extend({
   showDelay: DEFAULTS.showDelay,
   showDuration: DEFAULTS.showDuration,
   showOn: DEFAULTS.showOn,
-  target: computed(function() {
-    return (typeof FastBoot === 'undefined') ? this.element.parentNode : null;
-  }),
+  target: null,
 
   /**
    * ================== PRIVATE IMPLEMENTATION DETAILS ==================
    */
+
+  actions: {
+    onFoundTarget(target) {
+      this.set('_target', target);
+    }
+  },
 
   // Part of the Component superclass. isVisible == false sets 'display: none'
   isVisible: alias('renderInPlace'),
 
   init() {
     this._super(...arguments);
+
+    this.id = this.id || generateGuid();
 
     let options = getOwner(this).resolveRegistration('config:environment').emberAttacher;
 

--- a/addon/templates/components/ember-attacher.hbs
+++ b/addon/templates/components/ember-attacher.hbs
@@ -1,7 +1,9 @@
-{{#ember-popper eventsEnabled=false
+{{#ember-popper class=class
+                eventsEnabled=false
+                id=id
                 modifiers=_modifiers
+                onFoundTarget=(action 'onFoundTarget')
                 placement=placement
-                class=popperClass
                 popperContainer=popperContainer
                 renderInPlace=renderInPlace
                 target=target as |emberPopper|}}
@@ -22,7 +24,7 @@
                           showDelay=showDelay
                           showDuration=showDuration
                           showOn=showOn
-                          target=target as |inner|}}
+                          target=_target as |inner|}}
     {{yield (hash emberPopper=emberPopper
                   hide=inner.hide)}}
   {{/ember-attacher-inner}}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ember-cli-babel": "^6.8.1",
     "ember-cli-htmlbars": "^2.0.2",
     "ember-cli-sass": "^7.0.0",
-    "ember-popper": "^0.5.1",
+    "ember-popper": "^0.6.0",
     "ember-truth-helpers": "^1.3.0"
   },
   "devDependencies": {

--- a/tests/integration/components/ember-attacher-test.js
+++ b/tests/integration/components/ember-attacher-test.js
@@ -1,5 +1,4 @@
 import hbs from 'htmlbars-inline-precompile';
-import wait from 'ember-test-helpers/wait';
 import { click, find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -12,7 +11,7 @@ test('it renders', function(assert) {
 
   this.render(hbs`
     <div>
-      {{#ember-attacher popperClass="hello"}}
+      {{#ember-attacher class='hello'}}
         popper text
       {{/ember-attacher}}
     </div>
@@ -58,14 +57,15 @@ test('nested attachers open and close as expected', async function(assert) {
 
       {{#ember-attacher hideOn=hideOn
                         isShown=parentIsShown
-                        popperClass="parent"
+                        class='parent'
                         showOn=showOn}}
         <button id="openChild" {{action 'openChildPopover'}}>
           Open child
 
-          {{#ember-attacher hideOn=hideOn
+          {{#ember-attacher hideDuration=0
+                            hideOn=hideOn
                             isShown=childIsShown
-                            popperClass="child"
+                            class='child'
                             showOn=showOn}}
             <button id="closeChild" {{action 'closeChildPopover'}}>
               Close child
@@ -75,9 +75,6 @@ test('nested attachers open and close as expected', async function(assert) {
       {{/ember-attacher}}
     </button>
   `);
-
-  // Need to wait for didInsertElement to process
-  await wait();
 
   let child = find('.child', document.documentElement);
   let innerChildAttacher = find('.inner', child);
@@ -116,15 +113,12 @@ test('isShown works with showOn/hideOn set to "click"', async function(assert) {
 
       {{#ember-attacher hideOn=hideOn
                         isShown=isShown
-                        popperClass="hello"
+                        class='hello'
                         showOn=showOn}}
         isShown w/ hideOn/ShowOn of 'click'
       {{/ember-attacher}}
     </button>
   `);
-
-  // Need to wait for didInsertElement to process
-  await wait();
 
   let popper = find('.hello', document.documentElement);
   let innerAttacher = find('.inner', popper);
@@ -132,8 +126,6 @@ test('isShown works with showOn/hideOn set to "click"', async function(assert) {
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   await click(find('#toggle-show', document.documentElement));
-
-  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 
@@ -165,7 +157,7 @@ test('isShown works with showOn/hideOn set to "none"', async function(assert) {
 
       {{#ember-attacher hideOn=hideOn
                         isShown=isShown
-                        popperClass="hello"
+                        class='hello'
                         showOn=showOn}}
         isShown w/ hideOn/ShowOn of 'none'
 
@@ -204,15 +196,12 @@ test('showOn/hideOn set to "click"', async function(assert) {
       Click me, captain!
 
       {{#ember-attacher hideOn=hideOn
-                        popperClass="hello"
+                        class='hello'
                         showOn=showOn}}
         showOn/hideOn "click"
       {{/ember-attacher}}
     </button>
   `);
-
-  // Need to wait for didInsertElement to add the click listener
-  await wait();
 
   let popper = find('.hello', document.documentElement);
   let innerAttacher = find('.inner', popper);
@@ -220,8 +209,6 @@ test('showOn/hideOn set to "click"', async function(assert) {
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
   await click(find('#click-toggle', document.documentElement));
-
-  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Now shown');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,9 +2537,9 @@ ember-native-dom-helpers@^0.5.3:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"
 
-ember-popper@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.5.1.tgz#433c863efdc3df611d42846f6dfaad1bb1403f8a"
+ember-popper@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.6.0.tgz#18fa26b2e3bd4a41d161fc0d054d7e49359e100c"
   dependencies:
     babel-eslint "^7.2.3"
     babel-plugin-filter-imports "^0.3.1"


### PR DESCRIPTION
Implements #41 
Paves the way for #37 

I'm really happy with the changes introduced here:

1. We can now pass `class` and `id` directly to the popper element
2. No more ghost element where the `{{ember-attacher}}` was declared
3. Much cleaner tests now that we don't rely on `didInsertElement`
4. Greatly simplified internals now that we grab `target` from ember-popper instead of recalculating it ourselves
