### PR TITLE
Test fixups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ cache:
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-lts-2.4
-  - EMBER_TRY_SCENARIO=ember-lts-2.8
+  - EMBER_TRY_SCENARIO=ember-lts-2.12
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,36 +2,10 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-lts-2.4',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-4'
-        },
-        resolutions: {
-          'ember': 'lts-2-4'
-        }
-      },
+      name: 'ember-lts-2.12',
       npm: {
         devDependencies: {
-          'ember-native-dom-event-dispatcher': null,
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-lts-2.8',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-8'
-        },
-        resolutions: {
-          'ember': 'lts-2-8'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-native-dom-event-dispatcher': null,
-          'ember-source': null
+          'ember-source': '~2.12.0'
         }
       }
     },

--- a/tests/integration/components/attach-tooltip-test.js
+++ b/tests/integration/components/attach-tooltip-test.js
@@ -1,7 +1,17 @@
+import QUnit from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { find } from 'ember-native-dom-helpers';
 import { getOwner } from '@ember/application';
 import { moduleForComponent, test } from 'ember-qunit';
+
+QUnit.assert.contains = function(actual, expected, message) {
+  this.pushResult({
+    result: expected.every((elem) => actual.includes(elem)),
+    actual,
+    expected,
+    message
+  });
+};
 
 moduleForComponent('attach-tooltip', 'Integration | Component | attach tooltip', {
   afterEach() {
@@ -27,10 +37,9 @@ test('has the default classes', function(assert) {
 
   const tooltipWithClass = find('#tooltip-with-class');
 
-  assert.ok(
-    tooltipWithClass
-      .className
-      .startsWith('ember-attacher-popper ember-attacher-tooltip some-class'),
+  assert.contains(
+    tooltipWithClass.className.split(' '),
+    'ember-attacher-popper ember-attacher-tooltip some-class'.split(' '),
     'it adds the default classes to tooltips with a class'
   );
 
@@ -65,7 +74,7 @@ test('uses the user-supplied default tooltip class', function(assert) {
   );
 });
 
-test('it adds aria-describedby to the target and has the default classes', function(assert) {
+test('adds aria-describedby to the target', function(assert) {
   this.set('showTooltip', true);
 
   this.render(hbs`

--- a/tests/integration/components/ember-attacher/ember-attacher-test.js
+++ b/tests/integration/components/ember-attacher/ember-attacher-test.js
@@ -11,13 +11,13 @@ test('it renders', function(assert) {
 
   this.render(hbs`
     <div>
-      {{#ember-attacher class='hello'}}
+      {{#ember-attacher id='attachment'}}
         popper text
       {{/ember-attacher}}
     </div>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.ok(innerAttacher, '.inner class exists');
 

--- a/tests/integration/components/ember-attacher/hide-on-blur-test.js
+++ b/tests/integration/components/ember-attacher/hide-on-blur-test.js
@@ -7,7 +7,7 @@ moduleForComponent('ember-attacher', 'Integration | Component | hideOn "blur"', 
   integration: true
 });
 
-test('hides when the target loses focus', function(assert) {
+test('hides when the target loses focus', async function(assert) {
   assert.expect(3);
 
   this.render(hbs`
@@ -16,7 +16,7 @@ test('hides when the target loses focus', function(assert) {
     <button id="click-toggle">
       Click me, captain!
 
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='blur'
                         showOn='click'}}
         hideOn click
@@ -24,22 +24,22 @@ test('hides when the target loses focus', function(assert) {
     </button>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
-  return click(find('#click-toggle')).then(() => {
-    assert.equal(innerAttacher.style.display, '', 'Now shown');
+  await click(find('#click-toggle'));
 
-    document.getElementById('focus-me').focus();
+  assert.equal(innerAttacher.style.display, '', 'Now shown');
 
-    return wait().then(() => {
-      assert.equal(innerAttacher.style.display, 'none', 'hidden again');
-    });
-  });
+  document.getElementById('focus-me').focus();
+
+  await wait();
+
+  assert.equal(innerAttacher.style.display, 'none', 'hidden again');
 });
 
-test('with interactive=false: hides when the attachment gains focus', function(assert) {
+test('with interactive=false: hides when the attachment gains focus', async function(assert) {
   assert.expect(3);
 
   this.render(hbs`
@@ -48,7 +48,7 @@ test('with interactive=false: hides when the attachment gains focus', function(a
     <button id="click-toggle">
       Click me, captain!
 
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='blur'
                         showOn='click'}}
         <input type="text" id="attachment-focus-me"/>
@@ -56,22 +56,22 @@ test('with interactive=false: hides when the attachment gains focus', function(a
     </button>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
-  return click(find('#click-toggle')).then(() => {
-    assert.equal(innerAttacher.style.display, '', 'Now shown');
+  await click(find('#click-toggle'));
 
-    document.getElementById('attachment-focus-me').focus();
+  assert.equal(innerAttacher.style.display, '', 'Now shown');
 
-    return wait().then(() => {
-      assert.equal(innerAttacher.style.display, 'none', 'hidden again');
-    });
-  });
+  document.getElementById('attachment-focus-me').focus();
+
+  await wait();
+
+  assert.equal(innerAttacher.style.display, 'none', 'hidden again');
 });
 
-test("with interactive=true: doesn't hide when the attachment gains focus", function(assert) {
+test("with interactive=true: doesn't hide when attachment gains focus", async function(assert) {
   assert.expect(4);
 
   this.render(hbs`
@@ -80,7 +80,7 @@ test("with interactive=true: doesn't hide when the attachment gains focus", func
     <button id="click-toggle">
       Click me, captain!
 
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='blur'
                         interactive=true
                         showOn='click'}}
@@ -89,23 +89,23 @@ test("with interactive=true: doesn't hide when the attachment gains focus", func
     </button>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
-  return click(find('#click-toggle')).then(() => {
-    assert.equal(innerAttacher.style.display, '', 'Now shown');
+  await click(find('#click-toggle'));
 
-    document.getElementById('attachment-focus-me').focus();
+  assert.equal(innerAttacher.style.display, '', 'Now shown');
 
-    return wait().then(() => {
-      assert.equal(innerAttacher.style.display, '', 'Still shown');
+  document.getElementById('attachment-focus-me').focus();
 
-      document.getElementById('outer-focus-me').focus();
+  await wait();
 
-      return wait().then(() => {
-        assert.equal(innerAttacher.style.display, '', 'Hidden again');
-      });
-    });
-  });
+  assert.equal(innerAttacher.style.display, '', 'Still shown');
+
+  document.getElementById('outer-focus-me').focus();
+
+  await wait();
+
+  assert.equal(innerAttacher.style.display, '', 'Hidden again');
 });

--- a/tests/integration/components/ember-attacher/hide-on-click-test.js
+++ b/tests/integration/components/ember-attacher/hide-on-click-test.js
@@ -6,14 +6,14 @@ moduleForComponent('ember-attacher', 'Integration | Component | hideOn "click"',
   integration: true
 });
 
-test('hides when the target is clicked', function(assert) {
+test('hides when the target is clicked', async function(assert) {
   assert.expect(2);
 
   this.render(hbs`
     <button id="click-toggle">
       Click me, captain!
 
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='click'
                         isShown=true}}
         hideOn click
@@ -21,11 +21,11 @@ test('hides when the target is clicked', function(assert) {
     </button>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
-  return click(find('#click-toggle')).then(() => {
-    assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
-  });
+  await click(find('#click-toggle'));
+
+  assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 });

--- a/tests/integration/components/ember-attacher/hide-on-clickout-test.js
+++ b/tests/integration/components/ember-attacher/hide-on-clickout-test.js
@@ -6,14 +6,14 @@ moduleForComponent('ember-attacher', 'Integration | Component | hideOn "clickout
   integration: true
 });
 
-test('hides when an element outside the target is clicked', function(assert) {
+test('hides when an element outside the target is clicked', async function(assert) {
   assert.expect(3);
 
   this.render(hbs`
     <input type="text" id="focus-me"/>
 
     <div id="parent">
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='clickout'
                         isShown=true}}
         hideOn click
@@ -21,26 +21,26 @@ test('hides when an element outside the target is clicked', function(assert) {
     </div>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   // Make sure the attachment is still shown when the target is clicked
-  return click(find('#parent')).then(() => {
-    assert.equal(innerAttacher.style.display, '', 'Still shown');
+  await click(find('#parent'));
 
-    return click(find('#focus-me')).then(() => {
-      assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
-    });
-  });
+  assert.equal(innerAttacher.style.display, '', 'Still shown');
+
+  await click(find('#focus-me'));
+
+  assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 });
 
-test('with interactive=false: hides when attachment is clicked', function(assert) {
+test('with interactive=false: hides when attachment is clicked', async function(assert) {
   assert.expect(2);
 
   this.render(hbs`
     <div id="parent">
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='clickout'
                         isShown=true}}
         hideOn click
@@ -48,23 +48,23 @@ test('with interactive=false: hides when attachment is clicked', function(assert
     </div>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
-  return click(innerAttacher).then(() => {
-    assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
-  });
+  await click(innerAttacher);
+
+  assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 });
 
-test("with interactive=true: doesn't hide when attachment is clicked", function(assert) {
+test("with interactive=true: doesn't hide when attachment is clicked", async function(assert) {
   assert.expect(4);
 
   this.render(hbs`
     <input type="text" id="focus-me"/>
 
     <div id="parent">
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='clickout'
                         interactive=true
                         isShown=true}}
@@ -73,22 +73,22 @@ test("with interactive=true: doesn't hide when attachment is clicked", function(
     </div>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   // Make sure attachment stays shown when attachment clicked
-  return click(innerAttacher).then(() => {
-    assert.equal(innerAttacher.style.display, '', 'Still shown');
+  await click(innerAttacher);
 
-    // Make sure attachment stays shown when target clicked
-    return click(find('#parent')).then(() => {
-      assert.equal(innerAttacher.style.display, '', 'Still shown');
+  assert.equal(innerAttacher.style.display, '', 'Still shown');
 
-      // Make sure attachment is hidden once an element outside target or attachment is clicked
-      return click(find('#focus-me')).then(() => {
-        assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
-      });
-    });
-  });
+  // Make sure attachment stays shown when target clicked
+  await click(find('#parent'));
+
+  assert.equal(innerAttacher.style.display, '', 'Still shown');
+
+  // Make sure attachment is hidden once an element outside target or attachment is clicked
+  await click(find('#focus-me'));
+
+  assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 });

--- a/tests/integration/components/ember-attacher/hide-on-escapekey-test.js
+++ b/tests/integration/components/ember-attacher/hide-on-escapekey-test.js
@@ -6,12 +6,12 @@ moduleForComponent('ember-attacher', 'Integration | Component | hideOn "escapeke
   integration: true
 });
 
-test('hides when the escape key is pressed', function(assert) {
+test('hides when the escape key is pressed', async function(assert) {
   assert.expect(2);
 
   this.render(hbs`
     <div>
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='escapekey'
                         isShown=true}}
         hideOn click
@@ -19,12 +19,12 @@ test('hides when the escape key is pressed', function(assert) {
     </div>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   // Press escape key (keyCode === 27)
-  return keyEvent(document, 'keydown', 27).then(() => {
-    assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
-  });
+  await keyEvent(document, 'keydown', 27);
+
+  assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 });

--- a/tests/integration/components/ember-attacher/hide-on-focusout-test.js
+++ b/tests/integration/components/ember-attacher/hide-on-focusout-test.js
@@ -7,7 +7,7 @@ moduleForComponent('ember-attacher', 'Integration | Component | hideOn "focusout
   integration: true
 });
 
-test('hides when the target loses focus', function(assert) {
+test('hides when the target loses focus', async function(assert) {
   assert.expect(3);
 
   this.render(hbs`
@@ -16,7 +16,7 @@ test('hides when the target loses focus', function(assert) {
     <button id="click-toggle">
       Click me, captain!
 
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='focusout'
                         showOn='click'}}
         hideOn click
@@ -24,22 +24,22 @@ test('hides when the target loses focus', function(assert) {
     </button>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
-  return click(find('#click-toggle')).then(() => {
-    assert.equal(innerAttacher.style.display, '', 'Now shown');
+  await click(find('#click-toggle'));
 
-    document.getElementById('focus-me').focus();
+  assert.equal(innerAttacher.style.display, '', 'Now shown');
 
-    return wait().then(() => {
-      assert.equal(innerAttacher.style.display, 'none', 'hidden again');
-    });
-  });
+  document.getElementById('focus-me').focus();
+
+  await wait();
+
+  assert.equal(innerAttacher.style.display, 'none', 'hidden again');
 });
 
-test('with interactive=false: hides when the attachment gains focus', function(assert) {
+test('with interactive=false: hides when the attachment gains focus', async function(assert) {
   assert.expect(3);
 
   this.render(hbs`
@@ -48,7 +48,7 @@ test('with interactive=false: hides when the attachment gains focus', function(a
     <button id="click-toggle">
       Click me, captain!
 
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='focusout'
                         showOn='click'}}
         <input type="text" id="attachment-focus-me"/>
@@ -56,22 +56,22 @@ test('with interactive=false: hides when the attachment gains focus', function(a
     </button>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
-  return click(find('#click-toggle')).then(() => {
-    assert.equal(innerAttacher.style.display, '', 'Now shown');
+  await click(find('#click-toggle'));
 
-    document.getElementById('attachment-focus-me').focus();
+  assert.equal(innerAttacher.style.display, '', 'Now shown');
 
-    return wait().then(() => {
-      assert.equal(innerAttacher.style.display, 'none', 'hidden again');
-    });
-  });
+  document.getElementById('attachment-focus-me').focus();
+
+  await wait();
+
+  assert.equal(innerAttacher.style.display, 'none', 'hidden again');
 });
 
-test("with interactive=true: doesn't hide when the attachment gains focus", function(assert) {
+test("with interactive=true: doesn't hide when the attachment gains focus", async function(assert) {
   assert.expect(4);
 
   this.render(hbs`
@@ -80,7 +80,7 @@ test("with interactive=true: doesn't hide when the attachment gains focus", func
     <button id="click-toggle">
       Click me, captain!
 
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='focusout'
                         interactive=true
                         showOn='click'}}
@@ -89,23 +89,23 @@ test("with interactive=true: doesn't hide when the attachment gains focus", func
     </button>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
-  return click(find('#click-toggle')).then(() => {
-    assert.equal(innerAttacher.style.display, '', 'Now shown');
+  await click(find('#click-toggle'));
 
-    document.getElementById('attachment-focus-me').focus();
+  assert.equal(innerAttacher.style.display, '', 'Now shown');
 
-    return wait().then(() => {
-      assert.equal(innerAttacher.style.display, '', 'Still shown');
+  document.getElementById('attachment-focus-me').focus();
 
-      document.getElementById('outer-focus-me').focus();
+  await wait();
 
-      return wait().then(() => {
-        assert.equal(innerAttacher.style.display, '', 'Hidden again');
-      });
-    });
-  });
+  assert.equal(innerAttacher.style.display, '', 'Still shown');
+
+  document.getElementById('outer-focus-me').focus();
+
+  await wait();
+
+  assert.equal(innerAttacher.style.display, '', 'Hidden again');
 });

--- a/tests/integration/components/ember-attacher/hide-on-mouseleave-test.js
+++ b/tests/integration/components/ember-attacher/hide-on-mouseleave-test.js
@@ -7,7 +7,7 @@ moduleForComponent('ember-attacher', 'Integration | Component | hideOn "mouselea
   integration: true
 });
 
-test('hides when the mouse leaves the target', function(assert) {
+test('hides when the mouse leaves the target', async function(assert) {
   assert.expect(2);
 
   this.render(hbs`
@@ -24,12 +24,12 @@ test('hides when the mouse leaves the target', function(assert) {
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
-  return triggerEvent('#target', 'mouseleave').then(() => {
-    assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
-  });
+  await triggerEvent('#target', 'mouseleave');
+
+  assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 });
 
-test("with interactive=true: doesn't hide if mouse over target or attachment", function(assert) {
+test("with interactive=true: doesn't hide if mouse over target or attachment", async function(assert) {
   assert.expect(5);
 
   this.render(hbs`
@@ -52,29 +52,29 @@ test("with interactive=true: doesn't hide if mouse over target or attachment", f
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
-  return triggerEvent(target, 'mouseleave').then(() => {
-    // Sanity check still shown
-    assert.equal(innerAttacher.style.display, '', 'Still shown after mouseleave');
+  await triggerEvent(target, 'mouseleave');
 
-    return triggerEvent(innerAttacher, 'mousemove').then(() => {
-      assert.equal(innerAttacher.style.display, '', 'Still shown after mousemove into attachment');
+  // Sanity check still shown
+  assert.equal(innerAttacher.style.display, '', 'Still shown after mouseleave');
 
-      return triggerEvent(find('#other'), 'mousemove').then(() => {
-        assert.equal(innerAttacher.style.display, '', 'Still shown after mousemove into target');
+  await triggerEvent(innerAttacher, 'mousemove');
 
-        return triggerEvent(find('#outside'), 'mousemove').then(() => {
-          assert.equal(innerAttacher.style.display,
-                       'none',
-                       'Hidden after mousemove outside target and attachment');
-        });
-      });
-    });
-  });
+  assert.equal(innerAttacher.style.display, '', 'Still shown after mousemove into attachment');
+
+  await triggerEvent(find('#other'), 'mousemove');
+
+  assert.equal(innerAttacher.style.display, '', 'Still shown after mousemove into target');
+
+  await triggerEvent(find('#outside'), 'mousemove');
+
+  assert.equal(innerAttacher.style.display,
+               'none',
+               'Hidden after mousemove outside target and attachment');
 });
 
 // Regression test
 test('with interactive=true: still hides when mouse leaves target + attachment '
-     + 'after a manual hide', function(assert) {
+     + 'after a manual hide', async function(assert) {
   assert.expect(4);
 
   this.set('isShown', true);
@@ -99,28 +99,27 @@ test('with interactive=true: still hides when mouse leaves target + attachment '
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
-  return click(find('#manual-hide')).then(() => {
-    assert.equal(innerAttacher.style.display, 'none', 'Hidden after manual hide');
+  await click(find('#manual-hide'));
 
-    // Make visible again
-    this.set('isShown', true);
+  assert.equal(innerAttacher.style.display, 'none', 'Hidden after manual hide');
 
-    // Need to wait for mouseleave listener to be set, then trigger it
-    return wait().then(() => {
-      return triggerEvent('#target', 'mouseleave').then(() => {
-        // Sanity check. Also note how the mouseleave didn't trigger a hide event
-        assert.equal(innerAttacher.style.display, '', 'Shown again');
+  // Make visible again
+  this.set('isShown', true);
 
-        return triggerEvent(find('#outside'), 'mousemove').then(() => {
-          assert.equal(innerAttacher.style.display, 'none', 'Hidden after mousemove');
-        });
-      });
-    });
-  });
+  // Need to wait for mouseleave listener to be set, then trigger it
+  await wait();
+
+  await triggerEvent('#target', 'mouseleave');
+  // Sanity check. Also note how the mouseleave didn't trigger a hide event
+  assert.equal(innerAttacher.style.display, '', 'Shown again');
+
+  await triggerEvent(find('#outside'), 'mousemove');
+
+  assert.equal(innerAttacher.style.display, 'none', 'Hidden after mousemove');
 });
 
 test('with interactive=true and isOffset=false: hides if mouse between '
-     + 'target and attachment', function(assert) {
+     + 'target and attachment', async function(assert) {
   assert.expect(3);
 
   this.render(hbs`
@@ -146,25 +145,25 @@ test('with interactive=true and isOffset=false: hides if mouse between '
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
-  return triggerEvent(target, 'mouseleave').then(() => {
-    // Sanity check still shown
-    assert.equal(innerAttacher.style.display, '', 'Still shown after mouseleave');
+  await triggerEvent(target, 'mouseleave');
 
-    const attachmentPosition = find('#attachment').getBoundingClientRect();
+  // Sanity check still shown
+  assert.equal(innerAttacher.style.display, '', 'Still shown after mouseleave');
 
-    return triggerEvent(document,
-                        'mousemove',
-                        {
-                          clientX: attachmentPosition.left + 1,
-                          clientY: attachmentPosition.top - 1
-                        }).then(() => {
-      assert.equal(innerAttacher.style.display, 'none', 'Hidden after mousemove between');
-    });
-  });
+  const attachmentPosition = find('#attachment').getBoundingClientRect();
+
+  await triggerEvent(document,
+                     'mousemove',
+                     {
+                       clientX: attachmentPosition.left + 1,
+                       clientY: attachmentPosition.top - 1
+                     });
+
+  assert.equal(innerAttacher.style.display, 'none', 'Hidden after mousemove between');
 });
 
 test("with interactive=true and isOffset=true: doesn't hide if mouse between "
-     + 'target and attachment', function(assert) {
+     + 'target and attachment', async function(assert) {
   assert.expect(4);
 
   this.render(hbs`
@@ -191,28 +190,28 @@ test("with interactive=true and isOffset=true: doesn't hide if mouse between "
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
-  return triggerEvent(target, 'mouseleave').then(() => {
-    // Sanity check still shown
-    assert.equal(innerAttacher.style.display, '', 'Still shown after mouseleave');
+  await triggerEvent(target, 'mouseleave');
 
-    const attachmentPosition = find('#attachment').getBoundingClientRect();
+  // Sanity check still shown
+  assert.equal(innerAttacher.style.display, '', 'Still shown after mouseleave');
 
-    return triggerEvent(document,
-                        'mousemove',
-                        {
-                          clientX: attachmentPosition.left + 1,
-                          clientY: attachmentPosition.top - 1
-                        }).then(() => {
-      assert.equal(innerAttacher.style.display, '', 'Still shown after mousemove into between');
+  const attachmentPosition = find('#attachment').getBoundingClientRect();
 
-      return triggerEvent(document,
-                          'mousemove',
-                          {
-                            clientX: attachmentPosition.left - 1,
-                            clientY: attachmentPosition.bottom + 1
-                          }).then(() => {
-        assert.equal(innerAttacher.style.display, 'none', 'hidden after mousemove outside');
-      });
-    });
-  });
+  await triggerEvent(document,
+                     'mousemove',
+                     {
+                       clientX: attachmentPosition.left + 1,
+                       clientY: attachmentPosition.top - 1
+                     });
+
+  assert.equal(innerAttacher.style.display, '', 'Still shown after mousemove into between');
+
+  await triggerEvent(document,
+                     'mousemove',
+                     {
+                       clientX: attachmentPosition.left - 1,
+                       clientY: attachmentPosition.bottom + 1
+                     });
+
+  assert.equal(innerAttacher.style.display, 'none', 'hidden after mousemove outside');
 });

--- a/tests/integration/components/ember-attacher/is-shown-test.js
+++ b/tests/integration/components/ember-attacher/is-shown-test.js
@@ -6,14 +6,14 @@ moduleForComponent('ember-attacher', 'Integration | Component | isShown', {
   integration: true
 });
 
-test('isShown works with showOn/hideOn set to "click"', function(assert) {
+test('isShown works with showOn/hideOn set to "click"', async function(assert) {
   assert.expect(3);
 
   this.render(hbs`
     <button id="toggle-show">
       Click me, captain!
 
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='click'
                         isShown=true
                         showOn='click'}}
@@ -22,20 +22,20 @@ test('isShown works with showOn/hideOn set to "click"', function(assert) {
     </button>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
-  return click(find('#toggle-show')).then(() => {
-    assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
+  await click(find('#toggle-show'));
 
-    return click(find('#toggle-show')).then(() => {
-      assert.equal(innerAttacher.style.display, '', 'Shown again after click');
-    });
-  });
+  assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
+
+  await click(find('#toggle-show'));
+
+  assert.equal(innerAttacher.style.display, '', 'Shown again after click');
 });
 
-test('isShown works with showOn/hideOn set to "none"', function(assert) {
+test('isShown works with showOn/hideOn set to "none"', async function(assert) {
   assert.expect(3);
 
   this.on('closePopover', () => {
@@ -52,7 +52,7 @@ test('isShown works with showOn/hideOn set to "none"', function(assert) {
     <button id="open" {{action 'openPopover'}}>
       Click me, captain!
 
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='none'
                         isShown=isShown
                         showOn='none'}}
@@ -66,20 +66,20 @@ test('isShown works with showOn/hideOn set to "none"', function(assert) {
     </button>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
-  return click(find('#open')).then(() => {
-    assert.equal(innerAttacher.style.display, '', 'Now shown');
+  await click(find('#open'));
 
-    return click(find('#close')).then(() => {
-      assert.equal(innerAttacher.style.display, 'none', 'Hidden again');
-    });
-  });
+  assert.equal(innerAttacher.style.display, '', 'Now shown');
+
+  await click(find('#close'));
+
+  assert.equal(innerAttacher.style.display, 'none', 'Hidden again');
 });
 
-test('nested attachers open and close as expected', function(assert) {
+test('nested attachers open and close as expected', async function(assert) {
   assert.expect(6);
 
   this.on('openParentPopover', () => {
@@ -130,16 +130,16 @@ test('nested attachers open and close as expected', function(assert) {
   assert.equal(innerParentAttacher.style.display, 'none', 'parent initially hidden');
   assert.equal(innerChildAttacher.style.display, 'none', 'child initially hidden');
 
-  return click(find('#openParent')).then(() => {
-    assert.equal(innerParentAttacher.style.display, '', 'parent shown');
+  await click(find('#openParent'));
 
-    return click(find('#openChild', innerParentAttacher)).then(() => {
-      assert.equal(innerChildAttacher.style.display, '', 'child shown');
+  assert.equal(innerParentAttacher.style.display, '', 'parent shown');
 
-      return click(find('#closeChild')).then(() => {
-        assert.equal(innerChildAttacher.style.display, 'none', 'child hidden');
-        assert.equal(innerParentAttacher.style.display, '', 'parent still shown');
-      });
-    });
-  });
+  await click(find('#openChild', innerParentAttacher));
+
+  assert.equal(innerChildAttacher.style.display, '', 'child shown');
+
+  await click(find('#closeChild'));
+
+  assert.equal(innerChildAttacher.style.display, 'none', 'child hidden');
+  assert.equal(innerParentAttacher.style.display, '', 'parent still shown');
 });

--- a/tests/integration/components/ember-attacher/on-change-test.js
+++ b/tests/integration/components/ember-attacher/on-change-test.js
@@ -7,7 +7,7 @@ moduleForComponent('ember-attacher', 'Integration | Component | onChange', {
   integration: true
 });
 
-test('fires the onChange hook when visibility is toggled', function(assert) {
+test('fires the onChange hook when visibility is toggled', async function(assert) {
   assert.expect(5);
 
   this.set('isShown', true);
@@ -16,7 +16,7 @@ test('fires the onChange hook when visibility is toggled', function(assert) {
     <button id="click-toggle">
       Click me, captain!
 
-      {{#ember-attacher class='hello'
+      {{#ember-attacher id='attachment'
                         hideOn='click'
                         isShown=isShown
                         onChange=(action (mut isShown))
@@ -26,22 +26,22 @@ test('fires the onChange hook when visibility is toggled', function(assert) {
     </button>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
-  return click(find('#click-toggle')).then(() => {
-    assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
-    assert.equal(this.get('isShown'), false);
+  await click(find('#click-toggle'));
 
-    // Show again by toggling isShown
-    this.set('isShown', true);
+  assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
+  assert.equal(this.get('isShown'), false);
 
-    return wait().then(() => {
-      assert.equal(innerAttacher.style.display, '', 'Shown again');
+  // Show again by toggling isShown
+  this.set('isShown', true);
 
-      // Make sure isShown is still true
-      assert.equal(this.get('isShown'), true);
-    });
-  });
+  await wait();
+
+  assert.equal(innerAttacher.style.display, '', 'Shown again');
+
+  // Make sure isShown is still true
+  assert.equal(this.get('isShown'), true);
 });

--- a/tests/integration/components/ember-attacher/show-on-click-test.js
+++ b/tests/integration/components/ember-attacher/show-on-click-test.js
@@ -6,24 +6,24 @@ moduleForComponent('ember-attacher', 'Integration | Component | showOn "click"',
   integration: true
 });
 
-test('shows when the target is clicked', function(assert) {
+test('shows when the target is clicked', async function(assert) {
   assert.expect(2);
 
   this.render(hbs`
     <button id="click-toggle">
       Click me, captain!
 
-      {{#ember-attacher class='hello' showOn='click'}}
+      {{#ember-attacher id='attachment' showOn='click'}}
         showOn click
       {{/ember-attacher}}
     </button>
   `);
 
-  const innerAttacher = find('.hello > .inner');
+  const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
-  return click(find('#click-toggle')).then(() => {
-    assert.equal(innerAttacher.style.display, '', 'Now shown');
-  });
+  await click(find('#click-toggle'));
+
+  assert.equal(innerAttacher.style.display, '', 'Now shown');
 });


### PR DESCRIPTION
After going through broccolli hell, decided it isn't worth it to fix the 2.8 tests. AFAIK, ember-attacher should work fine all the way back to Ember-1.13.

Ember 2.8-LTS is going to be removed from LTS in ~6 weeks anyways.