### PR TITLE
Use RAF for animations

### DIFF
--- a/addon/components/ember-attacher-inner.js
+++ b/addon/components/ember-attacher-inner.js
@@ -231,8 +231,6 @@ export default Component.extend({
     // Make the attachment visible immediately so transition animations can take place
     this._setIsVisibleAfterDelay(true, 0);
 
-    this.get('scheduleUpdate')();
-
     this.get('enableEventListeners')();
 
     // Start the show animation on the next cycle so CSS transitions can have an effect
@@ -252,6 +250,7 @@ export default Component.extend({
       this.set('_transitionDuration', showDuration);
 
       this.set('_isStartingAnimation', true);
+
     });
 
     this._isHidden = false;

--- a/addon/templates/components/ember-attacher.hbs
+++ b/addon/templates/components/ember-attacher.hbs
@@ -19,7 +19,7 @@
                           isOffset=isOffset
                           isShown=isShown
                           onChange=onChange
-                          scheduleUpdate=emberPopper.scheduleUpdate
+                          update=emberPopper.update
                           showDelay=showDelay
                           showDuration=showDuration
                           showOn=showOn

--- a/tests/dummy/app/templates/components/attachment-example.hbs
+++ b/tests/dummy/app/templates/components/attachment-example.hbs
@@ -62,10 +62,10 @@
 <centered class="edit-section">
   <vbox lm="fit">
     <hbox class="nav-bar">
-      <centered fit class="nav{{if isConfiguringTooltip ' active'}}" {{action 'setIsConfiguringTooltip' true}}>
+      <centered xs='6' class="nav{{if isConfiguringTooltip ' active'}}" {{action 'setIsConfiguringTooltip' true}}>
         \{{#attach-tooltip}}
       </centered>
-      <centered fit class="nav{{unless isConfiguringTooltip ' active'}}" {{action 'setIsConfiguringTooltip' false}}>
+      <centered xs='6' class="nav{{unless isConfiguringTooltip ' active'}}" {{action 'setIsConfiguringTooltip' false}}>
         \{{#ember-attacher}}
       </centered>
     </hbox>

--- a/tests/integration/components/ember-attacher/hide-on-blur-test.js
+++ b/tests/integration/components/ember-attacher/hide-on-blur-test.js
@@ -1,6 +1,6 @@
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
-import { click, find } from 'ember-native-dom-helpers';
+import { click, find, focus } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 
 moduleForComponent('ember-attacher', 'Integration | Component | hideOn "blur"', {
@@ -29,11 +29,14 @@ test('hides when the target loses focus', async function(assert) {
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
   await click(find('#click-toggle'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Now shown');
 
-  document.getElementById('focus-me').focus();
+  await focus('#focus-me');
 
+  await wait();
   await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'hidden again');
@@ -61,11 +64,14 @@ test('with interactive=false: hides when the attachment gains focus', async func
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
   await click(find('#click-toggle'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Now shown');
 
-  document.getElementById('attachment-focus-me').focus();
+  await focus('#attachment-focus-me');
 
+  await wait();
   await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'hidden again');
@@ -94,17 +100,21 @@ test("with interactive=true: doesn't hide when attachment gains focus", async fu
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
   await click(find('#click-toggle'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Now shown');
 
-  document.getElementById('attachment-focus-me').focus();
+  await focus('#attachment-focus-me');
 
+  await wait();
   await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Still shown');
 
-  document.getElementById('outer-focus-me').focus();
+  await focus('#outer-focus-me');
 
+  await wait();
   await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Hidden again');

--- a/tests/integration/components/ember-attacher/hide-on-click-test.js
+++ b/tests/integration/components/ember-attacher/hide-on-click-test.js
@@ -1,4 +1,5 @@
 import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
 import { click, find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -21,11 +22,16 @@ test('hides when the target is clicked', async function(assert) {
     </button>
   `);
 
+  // Wait for the initial show() RAF to complete;
+  await wait();
+
   const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   await click(find('#click-toggle'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 });

--- a/tests/integration/components/ember-attacher/hide-on-clickout-test.js
+++ b/tests/integration/components/ember-attacher/hide-on-clickout-test.js
@@ -1,4 +1,5 @@
 import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
 import { click, find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -21,16 +22,24 @@ test('hides when an element outside the target is clicked', async function(asser
     </div>
   `);
 
+  // Wait for initial show animation to complete
+  await wait();
+  await wait();
+
   const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   // Make sure the attachment is still shown when the target is clicked
   await click(find('#parent'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Still shown');
 
   await click(find('#focus-me'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 });
@@ -48,11 +57,16 @@ test('with interactive=false: hides when attachment is clicked', async function(
     </div>
   `);
 
+  // Wait for initial show animation to complete
+  await wait();
+
   const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   await click(innerAttacher);
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 });
@@ -73,22 +87,31 @@ test("with interactive=true: doesn't hide when attachment is clicked", async fun
     </div>
   `);
 
+  // Wait for initial show animation to complete
+  await wait();
+
   const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   // Make sure attachment stays shown when attachment clicked
   await click(innerAttacher);
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Still shown');
 
   // Make sure attachment stays shown when target clicked
   await click(find('#parent'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Still shown');
 
   // Make sure attachment is hidden once an element outside target or attachment is clicked
   await click(find('#focus-me'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 });

--- a/tests/integration/components/ember-attacher/hide-on-escapekey-test.js
+++ b/tests/integration/components/ember-attacher/hide-on-escapekey-test.js
@@ -1,4 +1,5 @@
 import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
 import { find, keyEvent } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -19,12 +20,17 @@ test('hides when the escape key is pressed', async function(assert) {
     </div>
   `);
 
+  // Wait for initial show animation to complete
+  await wait();
+
   const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   // Press escape key (keyCode === 27)
   await keyEvent(document, 'keydown', 27);
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 });

--- a/tests/integration/components/ember-attacher/hide-on-focusout-test.js
+++ b/tests/integration/components/ember-attacher/hide-on-focusout-test.js
@@ -29,11 +29,14 @@ test('hides when the target loses focus', async function(assert) {
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
   await click(find('#click-toggle'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Now shown');
 
   document.getElementById('focus-me').focus();
 
+  await wait();
   await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'hidden again');
@@ -61,11 +64,15 @@ test('with interactive=false: hides when the attachment gains focus', async func
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
   await click(find('#click-toggle'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Now shown');
 
   document.getElementById('attachment-focus-me').focus();
 
+  // Make sure all deferables finish
+  await wait();
   await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'hidden again');
@@ -94,17 +101,21 @@ test("with interactive=true: doesn't hide when the attachment gains focus", asyn
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
   await click(find('#click-toggle'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Now shown');
 
   document.getElementById('attachment-focus-me').focus();
 
   await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Still shown');
 
   document.getElementById('outer-focus-me').focus();
 
+  await wait();
   await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Hidden again');

--- a/tests/integration/components/ember-attacher/hide-on-mouseleave-test.js
+++ b/tests/integration/components/ember-attacher/hide-on-mouseleave-test.js
@@ -20,11 +20,16 @@ test('hides when the mouse leaves the target', async function(assert) {
     </div>
   `);
 
+  // Wait for initial show()
+  await wait();
+
   const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   await triggerEvent('#target', 'mouseleave');
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 });
@@ -47,25 +52,36 @@ test("with interactive=true: doesn't hide if mouse over target or attachment", a
     <div id='outside'></div>
   `);
 
+  // Wait for initial show()
+  await wait();
+
   const innerAttacher = find('#hello > .inner');
   const target = find('#target');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   await triggerEvent(target, 'mouseleave');
+  await wait();
+  await wait();
 
   // Sanity check still shown
   assert.equal(innerAttacher.style.display, '', 'Still shown after mouseleave');
 
   await triggerEvent(innerAttacher, 'mousemove');
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Still shown after mousemove into attachment');
 
   await triggerEvent(find('#other'), 'mousemove');
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Still shown after mousemove into target');
 
   await triggerEvent(find('#outside'), 'mousemove');
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display,
                'none',
@@ -95,11 +111,15 @@ test('with interactive=true: still hides when mouse leaves target + attachment '
     <div id='outside'></div>
   `);
 
+  // Wait for initial show()
+  await wait();
+
   const innerAttacher = find('#hello > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   await click(find('#manual-hide'));
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Hidden after manual hide');
 
@@ -110,10 +130,15 @@ test('with interactive=true: still hides when mouse leaves target + attachment '
   await wait();
 
   await triggerEvent('#target', 'mouseleave');
+  await wait();
+  await wait();
+
   // Sanity check. Also note how the mouseleave didn't trigger a hide event
   assert.equal(innerAttacher.style.display, '', 'Shown again');
 
   await triggerEvent(find('#outside'), 'mousemove');
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Hidden after mousemove');
 });
@@ -140,12 +165,17 @@ test('with interactive=true and isOffset=false: hides if mouse between '
     </div>
   `);
 
+  // Wait for initial show()
+  await wait();
+
   const innerAttacher = find('#attachment > .inner');
   const target = find('#target');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   await triggerEvent(target, 'mouseleave');
+  await wait();
+  await wait();
 
   // Sanity check still shown
   assert.equal(innerAttacher.style.display, '', 'Still shown after mouseleave');
@@ -158,6 +188,8 @@ test('with interactive=true and isOffset=false: hides if mouse between '
                        clientX: attachmentPosition.left + 1,
                        clientY: attachmentPosition.top - 1
                      });
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Hidden after mousemove between');
 });
@@ -173,7 +205,8 @@ test("with interactive=true and isOffset=true: doesn't hide if mouse between "
       }
     </style>
 
-    <div id="target" style="height: 300px; width: 300px;">
+    <div id="target" style="height: 50px; top: 0; position: fixed; width: 300px;">
+      target
       {{#ember-attacher id='attachment'
                         hideOn='mouseleave'
                         interactive=true
@@ -185,12 +218,17 @@ test("with interactive=true and isOffset=true: doesn't hide if mouse between "
     </div>
   `);
 
+  // Wait for initial show()
+  await wait();
+
   const innerAttacher = find('#attachment > .inner');
   const target = find('#target');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   await triggerEvent(target, 'mouseleave');
+  await wait();
+  await wait();
 
   // Sanity check still shown
   assert.equal(innerAttacher.style.display, '', 'Still shown after mouseleave');
@@ -203,6 +241,8 @@ test("with interactive=true and isOffset=true: doesn't hide if mouse between "
                        clientX: attachmentPosition.left + 1,
                        clientY: attachmentPosition.top - 1
                      });
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Still shown after mousemove into between');
 
@@ -212,6 +252,8 @@ test("with interactive=true and isOffset=true: doesn't hide if mouse between "
                        clientX: attachmentPosition.left - 1,
                        clientY: attachmentPosition.bottom + 1
                      });
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'hidden after mousemove outside');
 });

--- a/tests/integration/components/ember-attacher/is-shown-test.js
+++ b/tests/integration/components/ember-attacher/is-shown-test.js
@@ -1,4 +1,5 @@
 import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
 import { click, find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -22,15 +23,22 @@ test('isShown works with showOn/hideOn set to "click"', async function(assert) {
     </button>
   `);
 
+  // Wait for the initial show() RAF to complete;
+  await wait();
+
   const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   await click(find('#toggle-show'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
 
   await click(find('#toggle-show'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Shown again after click');
 });
@@ -71,16 +79,20 @@ test('isShown works with showOn/hideOn set to "none"', async function(assert) {
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
   await click(find('#open'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Now shown');
 
   await click(find('#close'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Hidden again');
 });
 
 test('nested attachers open and close as expected', async function(assert) {
-  assert.expect(6);
+  assert.expect(7);
 
   this.on('openParentPopover', () => {
     this.set('parentIsShown', true);
@@ -131,15 +143,27 @@ test('nested attachers open and close as expected', async function(assert) {
   assert.equal(innerChildAttacher.style.display, 'none', 'child initially hidden');
 
   await click(find('#openParent'));
+  await wait();
+  await wait();
 
   assert.equal(innerParentAttacher.style.display, '', 'parent shown');
 
+  assert.equal(innerChildAttacher.style.display, 'none', 'child still hidden');
+
   await click(find('#openChild', innerParentAttacher));
+  await wait();
+  await wait();
+
+  // Wait for show animation to complete
+  await wait();
+  await wait();
 
   assert.equal(innerChildAttacher.style.display, '', 'child shown');
 
   await click(find('#closeChild'));
+  await wait();
+  await wait();
 
-  assert.equal(innerChildAttacher.style.display, 'none', 'child hidden');
   assert.equal(innerParentAttacher.style.display, '', 'parent still shown');
+  assert.equal(innerChildAttacher.style.display, 'none', 'child hidden');
 });

--- a/tests/integration/components/ember-attacher/on-change-test.js
+++ b/tests/integration/components/ember-attacher/on-change-test.js
@@ -26,11 +26,16 @@ test('fires the onChange hook when visibility is toggled', async function(assert
     </button>
   `);
 
+  // Wait for the initial show() RAF to complete;
+  await wait();
+
   const innerAttacher = find('#attachment > .inner');
 
   assert.equal(innerAttacher.style.display, '', 'Initially shown');
 
   await click(find('#click-toggle'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, 'none', 'Now hidden');
   assert.equal(this.get('isShown'), false);
@@ -38,6 +43,7 @@ test('fires the onChange hook when visibility is toggled', async function(assert
   // Show again by toggling isShown
   this.set('isShown', true);
 
+  await wait();
   await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Shown again');

--- a/tests/integration/components/ember-attacher/show-on-click-test.js
+++ b/tests/integration/components/ember-attacher/show-on-click-test.js
@@ -1,4 +1,5 @@
 import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
 import { click, find } from 'ember-native-dom-helpers';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -24,6 +25,8 @@ test('shows when the target is clicked', async function(assert) {
   assert.equal(innerAttacher.style.display, 'none', 'Initially hidden');
 
   await click(find('#click-toggle'));
+  await wait();
+  await wait();
 
   assert.equal(innerAttacher.style.display, '', 'Now shown');
 });


### PR DESCRIPTION
This makes things buttery smooth by greatly improving performance. It also fixes, once and for all, strange positioning issues that spur from `display: none` being toggled on the same repaint that animations take place.