### PR TITLE
fix(filters) downgrade babel-plugin-filter-imports

### DIFF
--- a/lib/babel-plugin-remove-imports.js
+++ b/lib/babel-plugin-remove-imports.js
@@ -4,18 +4,17 @@
 const path = require('path');
 
 function removeImports() {
-  let importDeclarationsToRemove;
-  let filteredImports;
+  let importDeclarationsToRemove, filteredImports;
 
   return {
     name: 'remove-filtered-imports',
     visitor: {
       Program: {
-        enter: function(_, state) {
+        enter(_, state) {
           filteredImports = state.opts instanceof Array ? state.opts : (state.opts ? [state.opts] : []);
           importDeclarationsToRemove = [];
         },
-        exit: function() {
+        exit() {
           importDeclarationsToRemove.forEach(function(declaration) {
             declaration.remove();
           });
@@ -24,7 +23,7 @@ function removeImports() {
         }
       },
 
-      ImportDeclaration: function(path) {
+      ImportDeclaration(path) {
         const name = path.node.source.value;
 
         if (filteredImports.indexOf(name) !== -1) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "babel-eslint": "^8.0.0",
-    "babel-plugin-filter-imports": "^1.0.3",
+    "babel-plugin-filter-imports": "^0.3.1",
     "babel6-plugin-strip-class-callcheck": "^6.0.0",
     "broccoli-funnel": "^2.0.1",
     "ember-cli-babel": "^6.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -678,13 +678,6 @@ babel-plugin-filter-imports@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-0.3.1.tgz#e7859b56886b175dd2616425d277b219e209ea8b"
 
-babel-plugin-filter-imports@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-1.0.3.tgz#d32bab3678fd2ff12aa3031634d31db82f4ae6a7"
-  dependencies:
-    babel-types "^6.26.0"
-    lodash "^4.17.4"
-
 babel-plugin-htmlbars-inline-precompile@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.3.tgz#cd365e278af409bfa6be7704c4354beee742446b"


### PR DESCRIPTION
Fixes #72 

The error persists even after updating to the new configuration style, so we'll just downgrade until we know why #72 occurs.