### PR TITLE
Adds lazyRender support

### DIFF
--- a/addon/components/ember-attacher-inner.js
+++ b/addon/components/ember-attacher-inner.js
@@ -167,6 +167,9 @@ export default Component.extend({
   _hideOn: computed('hideOn', function() {
     return this.get('hideOn').split(' ');
   }),
+  _shouldRender: computed('lazyRender', function() {
+    return !this.get('lazyRender');
+  }),
   _showOn: computed('showOn', function() {
     return this.get('showOn').split(' ');
   }),
@@ -223,6 +226,8 @@ export default Component.extend({
     if (!this._currentTarget) {
       return;
     }
+
+    this.set('_shouldRender', true);
 
     // Make the attachment visible immediately so transition animations can take place
     this._setIsVisibleAfterDelay(true, 0);

--- a/addon/components/ember-attacher.js
+++ b/addon/components/ember-attacher.js
@@ -43,6 +43,7 @@ export default Component.extend({
   interactive: DEFAULTS.interactive,
   isOffset: DEFAULTS.isOffset,
   isShown: DEFAULTS.isShown,
+  lazyRender: DEFAULTS.lazyRender,
   onChange: null,
   placement: DEFAULTS.placement,
   popperContainer: DEFAULTS.popperContainer,

--- a/addon/defaults.js
+++ b/addon/defaults.js
@@ -9,6 +9,7 @@ export default {
   interactive: false,
   isOffset: false,
   isShown: false,
+  lazyRender: false,
   placement: 'top',
   popperContainer: '.ember-application',
   popperOptions: null,

--- a/addon/templates/components/ember-attacher-inner.hbs
+++ b/addon/templates/components/ember-attacher-inner.hbs
@@ -1,7 +1,10 @@
-{{yield (hash hide=(action 'hide'))}}
-{{#if arrow}}
-  <div x-arrow></div>
-{{/if}}
-{{#if (eq animation 'fill')}}
-  <div x-circle style="{{circleTransitionDuration}}"></div>
+{{#if _shouldRender}}
+  {{yield (hash hide=(action 'hide'))}}
+
+  {{#if arrow}}
+    <div x-arrow></div>
+  {{/if}}
+  {{#if (eq animation 'fill')}}
+    <div x-circle style="{{circleTransitionDuration}}"></div>
+  {{/if}}
 {{/if}}

--- a/addon/templates/components/ember-attacher.hbs
+++ b/addon/templates/components/ember-attacher.hbs
@@ -19,6 +19,7 @@
                           interactive=interactive
                           isOffset=isOffset
                           isShown=isShown
+                          lazyRender=lazyRender
                           onChange=onChange
                           update=emberPopper.update
                           showDelay=showDelay

--- a/tests/dummy/app/components/attachment-example.js
+++ b/tests/dummy/app/components/attachment-example.js
@@ -38,6 +38,10 @@ export default Component.extend({
       this.get('service').toggleProperty('isShown');
     },
 
+    toggleLazyRender() {
+      this.get('service').toggleProperty('lazyRender');
+    },
+
     toggleRenderInPlace() {
       this.get('service').toggleProperty('renderInPlace');
     },

--- a/tests/dummy/app/services/popover-data.js
+++ b/tests/dummy/app/services/popover-data.js
@@ -8,6 +8,7 @@ export default Service.extend({
   hideOn: 'click',
   interactive: false,
   isShown: false,
+  lazyRender: false,
   placement: 'top',
   renderInPlace: false,
   showDelay: 0,

--- a/tests/dummy/app/templates/components/attachment-example.hbs
+++ b/tests/dummy/app/templates/components/attachment-example.hbs
@@ -34,6 +34,7 @@
                       hideOn=popoverData.hideOn
                       interactive=popoverData.interactive
                       isShown=popoverData.isShown
+                      lazyRender=popoverData.lazyRender
                       onChange=(action (mut popoverData.isShown))
                       placement=popoverData.placement
                       renderInPlace=popoverData.renderInPlace
@@ -202,6 +203,21 @@
         </span>
         =
         <button class="button medium" {{action "toggleIsShown"}}>{{service.isShown}}</button>
+      </centered>
+    </hbox>
+    <hbox>
+      &nbsp;&nbsp;&nbsp;&nbsp;
+      <box xs="hidden" lm="visible fit">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</box>
+      <centered fit>
+        <span class="underlined">
+          lazyRender
+
+          {{#attach-tooltip}}
+            If you want ember-attacher to postpone rendering until first interacted.
+          {{/attach-tooltip}}
+        </span>
+        =
+        <button class="button medium" {{action "toggleLazyRender"}}>{{service.lazyRender}}</button>
       </centered>
     </hbox>
     <hbox>

--- a/tests/integration/components/ember-attacher/lazy-render-test.js
+++ b/tests/integration/components/ember-attacher/lazy-render-test.js
@@ -1,0 +1,46 @@
+import hbs from 'htmlbars-inline-precompile';
+import {
+  click,
+  find
+} from 'ember-native-dom-helpers';
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('ember-attacher', 'Integration | Component | lazyRender', {
+  integration: true
+});
+
+test('will lazily render the yield block when lazyRender is passed as true', async function(assert) {
+  assert.expect(2);
+
+  this.render(hbs`
+    <button id="toggle-show">
+      Click me, captain!
+
+      {{#ember-attacher id='attachment' lazyRender=true}}
+        <div id='should-not-be-present-until-clicked'></div>
+      {{/ember-attacher}}
+    </button>
+  `);
+
+  assert.notOk(find('#should-not-be-present-until-clicked'), 'Has not initially rendered the yield block.');
+
+  await click('#toggle-show');
+
+  assert.ok(find('#should-not-be-present-until-clicked'), 'Has rendered the yield block.');
+});
+
+test('lazily render will default to false which will eager render the yeild block', async function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`
+    <button id="toggle-show">
+      Click me, captain!
+
+      {{#ember-attacher id='attachment'}}
+        <div id='should-not-be-present-until-clicked'></div>
+      {{/ember-attacher}}
+    </button>
+  `);
+
+  assert.ok(find('#should-not-be-present-until-clicked'), 'Has initially rendered the yield block.');
+});


### PR DESCRIPTION
This PR adds support to defer the render of the `yield` block in the `ember-attacher-inner` component. 

The motivation would be to defer the initialization work of the attached items until the user interacts with it. In cases where the yielded contents are complex, this is preferred over having many items initialize which might or might not ever be used. 

Adds a new property called `lazyRender` to the parent `ember-attacher` component. 
This `lazyRender` property defaults to false to maintain current expected behavior. 
Adds tests for lazyRendering to ensure contents are not rendered until after interacting.
Adds working example to the dummy app. 

@kybishop, I am looking for some feedback. Are there any additional tests or cases you want explored? 
I believe that once merged you will also need to deploy the dummy app to github pages. 
Also, I was not sure if this should be in the readme or not as many of the options are not currently enumerated there. 

Closes #74
Closes #64 (in my opinion)