### PR TITLE
feat: get hideOn clickout to work on iOS

### DIFF
--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -477,8 +477,10 @@ export default Component.extend({
     }
 
     if (hideOn.indexOf('clickout') !== -1) {
-      this._hideListenersOnDocumentByEvent.click = this._hideOnClickOut;
-      document.addEventListener('click', this._hideOnClickOut);
+      const clickoutEvent = 'ontouchstart' in window ? 'touchend' : 'click';
+
+      this._hideListenersOnDocumentByEvent[clickoutEvent] = this._hideOnClickOut;
+      document.addEventListener(clickoutEvent, this._hideOnClickOut);
     }
 
     if (hideOn.indexOf('escapekey') !== -1) {


### PR DESCRIPTION
On iOS, `document.addEventListener('click', handler)` dosen't work.
It means `hideOn='clickout'` also doesn't work on iOS.
Actually, I couldn't close popped up items by tapping outside of them.

This PR will fix this issue using touch events to simulate clicks on iOS.
The algorithm is quite simple - if a touched position doesn't move from start to finish, regard the action as a click then execute `this._hideOnClickOut(event)` handler.

Since I have no idea how I can add iOS specific tests, I haven't added any tests...