### PR TITLE
improves isVisible helper by also checking for class

### DIFF
--- a/addon-test-support/is-visible.js
+++ b/addon-test-support/is-visible.js
@@ -3,7 +3,7 @@ import { find } from 'ember-native-dom-helpers';
 export function isVisible(selector, contextEl) {
   const attachment = typeof(selector) === 'string' ? getAttachment(selector, contextEl) : selector;
 
-  return attachment.style.display !== 'none';
+  return attachment.style.display !== 'none' && !attachement.classList.contains('ember-attacher-hide');
 }
 
 function getAttachment(selector, contextEl) {


### PR DESCRIPTION
Hey,

I didn't dig into the internals of how the showing/hiding works with the pop-over, but in my acceptance tests, I found that the `isVisible` helper wasn't working. The attachment would have the class `ember-attacher-hide` but the `display` property was `''`.

This fix should make it return isVisible -> false whenever the `ember-attacher-hide` class is on the pop-over.