### PR TITLE
feat: works with placement modifiers (start/end)

### DIFF
--- a/addon/styles/ember-attacher.scss
+++ b/addon/styles/ember-attacher.scss
@@ -4,7 +4,7 @@
   z-index: 9999;
 
   @each $position in $positions {
-    &[x-placement=#{$position}] {
+    &[x-placement^=#{$position}] {
       div[x-arrow] {
         @include arrow($position, 10px);
       }

--- a/tests/dummy/app/components/attachment-example.js
+++ b/tests/dummy/app/components/attachment-example.js
@@ -20,7 +20,12 @@ export default Component.extend({
       'shift'
     ];
     this.hideOnOptions = ['click', 'clickout', 'mouseleave blur escapekey'];
-    this.placementOptions = ['bottom', 'left', 'right', 'top'];
+    this.placementOptions = [
+      'bottom', 'bottom-start', 'bottom-end',
+      'left', 'left-start', 'left-end',
+      'right', 'right-start', 'right-end',
+      'top', 'top-start', 'top-end',
+    ];
     this.showOnOptions = ['click', 'mouseenter focus'];
   },
 

--- a/tests/dummy/app/templates/components/attachment-example.hbs
+++ b/tests/dummy/app/templates/components/attachment-example.hbs
@@ -242,7 +242,7 @@
                                    options=placementOptions
                                    searchEnabled=false
                                    selected=service.placement
-                                   triggerClass="button medium"
+                                   triggerClass="button large"
                                    as |placementOption|}}
                                      {{placementOption}}
                                    {{/power-select}}"


### PR DESCRIPTION
Enable ember-attacher to work with the following placements:
* `bottom-start`
* `bottom-end`
* `left-start`
* `left-end`
* `right-start`
* `right-end`
* `top-start`
* `top-end`

Fixes #134 #139