### PR TITLE
Add useCapture option to add event listeners in the capturing phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A tooltip attacher. Subclass of `{{#attach-popover}}`
 
 ## Options
 
-Below is a list of all availabe options, along with their defaults.
+Below is a list of all available options, along with their defaults.
 
 ```javascript
 {
@@ -138,9 +138,15 @@ Below is a list of all availabe options, along with their defaults.
   // The duration, in milliseconds, of the show animation.
   showDuration: 300,
 
-   // Events on the target that will cause the attachment to show. For performance reasons, we
-   // recommend using some combination of 'mouseenter', 'focus', and 'click'
+  // Events on the target that will cause the attachment to show. For performance reasons, we
+  // recommend using some combination of 'mouseenter', 'focus', and 'click'
   showOn: 'mouseenter focus',
+
+  // Whether to add event listeners for attachment show and hide in the capturing phase rather
+  // than the bubbling phase. This should be set to true when there are elements on the page that
+  // are stopping event propagation in the bubbling phase, and as a result preventing correct
+  // showing and hiding of popovers and tooltips.
+  useCapture: false
 }
 ```
 

--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -334,7 +334,7 @@ export default Component.extend({
     this.get('_showOn').forEach((event) => {
       this._showListenersOnTargetByEvent[event] = this._showAfterDelay;
 
-      this._currentTarget.addEventListener(event, this._showAfterDelay);
+      this._currentTarget.addEventListener(event, this._showAfterDelay, true);
     });
   },
 
@@ -349,7 +349,7 @@ export default Component.extend({
 
   _removeEventListeners() {
     Object.keys(this._hideListenersOnDocumentByEvent).forEach((eventType) => {
-      document.removeEventListener(eventType, this._hideListenersOnDocumentByEvent[eventType]);
+      document.removeEventListener(eventType, this._hideListenersOnDocumentByEvent[eventType], true);
       delete this._hideListenersOnDocumentByEvent[eventType];
     });
 
@@ -360,7 +360,7 @@ export default Component.extend({
     [this._hideListenersOnTargetByEvent, this._showListenersOnTargetByEvent]
       .forEach((eventToListener) => {
         Object.keys(eventToListener).forEach((event) => {
-          this._currentTarget.removeEventListener(event, eventToListener[event]);
+          this._currentTarget.removeEventListener(event, eventToListener[event], true);
         });
       });
   },
@@ -512,39 +512,39 @@ export default Component.extend({
       const showOnClickListener = this._showListenersOnTargetByEvent.click;
 
       if (showOnClickListener) {
-        target.removeEventListener('click', showOnClickListener);
+        target.removeEventListener('click', showOnClickListener, true);
 
         delete this._showListenersOnTargetByEvent.click;
       }
 
       this._hideListenersOnTargetByEvent.click = this._hideAfterDelay;
-      target.addEventListener('click', this._hideAfterDelay);
+      target.addEventListener('click', this._hideAfterDelay, true);
     }
 
     if (hideOn.indexOf('clickout') !== -1) {
       const clickoutEvent = 'ontouchstart' in window ? 'touchend' : 'click';
 
       this._hideListenersOnDocumentByEvent[clickoutEvent] = this._hideOnClickOut;
-      document.addEventListener(clickoutEvent, this._hideOnClickOut);
+      document.addEventListener(clickoutEvent, this._hideOnClickOut, true);
     }
 
     if (hideOn.indexOf('escapekey') !== -1) {
       this._hideListenersOnDocumentByEvent.keydown = this._hideOnEscapeKey;
-      document.addEventListener('keydown', this._hideOnEscapeKey);
+      document.addEventListener('keydown', this._hideOnEscapeKey, true);
     }
 
     // Hides the attachment when the mouse leaves the target
     // (or leaves both target and attachment for interactive attachments)
     if (hideOn.indexOf('mouseleave') !== -1) {
       this._hideListenersOnTargetByEvent.mouseleave = this._hideOnMouseLeaveTarget;
-      target.addEventListener('mouseleave', this._hideOnMouseLeaveTarget);
+      target.addEventListener('mouseleave', this._hideOnMouseLeaveTarget, true);
     }
 
     // Hides the attachment when focus is lost on the target
     ['blur', 'focusout'].forEach((eventType) => {
       if (hideOn.indexOf(eventType) !== -1) {
         this._hideListenersOnTargetByEvent[eventType] = this._hideOnLostFocus;
-        target.addEventListener(eventType, this._hideOnLostFocus);
+        target.addEventListener(eventType, this._hideOnLostFocus, true);
       }
     });
   },
@@ -558,7 +558,7 @@ export default Component.extend({
       //   queue another fire at the end of the debounce period
       if (!this._hideListenersOnDocumentByEvent.mousemove) {
         this._hideListenersOnDocumentByEvent.mousemove = this._hideIfMouseOutsideTargetOrAttachment;
-        document.addEventListener('mousemove', this._hideIfMouseOutsideTargetOrAttachment);
+        document.addEventListener('mousemove', this._hideIfMouseOutsideTargetOrAttachment, true);
       }
     } else {
       this._hideAfterDelay();
@@ -578,7 +578,7 @@ export default Component.extend({
       && !this._popperElement.contains(event.target)) {
       // Remove this listener before hiding the attachment
       delete this._hideListenersOnDocumentByEvent.mousemove;
-      document.removeEventListener('mousemove', this._hideIfMouseOutsideTargetOrAttachment);
+      document.removeEventListener('mousemove', this._hideIfMouseOutsideTargetOrAttachment, true);
 
       this._hideAfterDelay();
     }
@@ -663,7 +663,7 @@ export default Component.extend({
 
   _removeListenersForHideEvents() {
     Object.keys(this._hideListenersOnDocumentByEvent).forEach((eventType) => {
-      document.removeEventListener(eventType, this._hideListenersOnDocumentByEvent[eventType]);
+      document.removeEventListener(eventType, this._hideListenersOnDocumentByEvent[eventType], true);
       delete this._hideListenersOnDocumentByEvent[eventType];
     });
 
@@ -680,19 +680,19 @@ export default Component.extend({
       const hideOnClickListener = this._hideListenersOnTargetByEvent.click;
 
       if (hideOnClickListener) {
-        target.removeEventListener('click', hideOnClickListener);
+        target.removeEventListener('click', hideOnClickListener, true);
         delete this._hideListenersOnTargetByEvent.click;
       }
 
       this._showListenersOnTargetByEvent.click = this._showAfterDelay;
-      target.addEventListener('click', this._showAfterDelay);
+      target.addEventListener('click', this._showAfterDelay, true);
     }
 
     ['blur', 'focusout', 'mouseleave'].forEach((eventType) => {
       const listener = this._hideListenersOnTargetByEvent[eventType];
 
       if (listener) {
-        target.removeEventListener(eventType, listener);
+        target.removeEventListener(eventType, listener, true);
         delete this._hideListenersOnTargetByEvent[eventType];
       }
     });

--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -41,6 +41,7 @@ export default Component.extend({
   showDuration: DEFAULTS.showDuration,
   showOn: DEFAULTS.showOn,
   style: DEFAULTS.style,
+  useCapture: DEFAULTS.useCapture,
 
   /**
    * ================== PRIVATE IMPLEMENTATION DETAILS ==================
@@ -334,7 +335,7 @@ export default Component.extend({
     this.get('_showOn').forEach((event) => {
       this._showListenersOnTargetByEvent[event] = this._showAfterDelay;
 
-      this._currentTarget.addEventListener(event, this._showAfterDelay, true);
+      this._currentTarget.addEventListener(event, this._showAfterDelay, this.get('useCapture'));
     });
   },
 
@@ -349,7 +350,7 @@ export default Component.extend({
 
   _removeEventListeners() {
     Object.keys(this._hideListenersOnDocumentByEvent).forEach((eventType) => {
-      document.removeEventListener(eventType, this._hideListenersOnDocumentByEvent[eventType], true);
+      document.removeEventListener(eventType, this._hideListenersOnDocumentByEvent[eventType], this.get('useCapture'));
       delete this._hideListenersOnDocumentByEvent[eventType];
     });
 
@@ -360,7 +361,7 @@ export default Component.extend({
     [this._hideListenersOnTargetByEvent, this._showListenersOnTargetByEvent]
       .forEach((eventToListener) => {
         Object.keys(eventToListener).forEach((event) => {
-          this._currentTarget.removeEventListener(event, eventToListener[event], true);
+          this._currentTarget.removeEventListener(event, eventToListener[event], this.get('useCapture'));
         });
       });
   },
@@ -512,39 +513,39 @@ export default Component.extend({
       const showOnClickListener = this._showListenersOnTargetByEvent.click;
 
       if (showOnClickListener) {
-        target.removeEventListener('click', showOnClickListener, true);
+        target.removeEventListener('click', showOnClickListener, this.get('useCapture'));
 
         delete this._showListenersOnTargetByEvent.click;
       }
 
       this._hideListenersOnTargetByEvent.click = this._hideAfterDelay;
-      target.addEventListener('click', this._hideAfterDelay, true);
+      target.addEventListener('click', this._hideAfterDelay, this.get('useCapture'));
     }
 
     if (hideOn.indexOf('clickout') !== -1) {
       const clickoutEvent = 'ontouchstart' in window ? 'touchend' : 'click';
 
       this._hideListenersOnDocumentByEvent[clickoutEvent] = this._hideOnClickOut;
-      document.addEventListener(clickoutEvent, this._hideOnClickOut, true);
+      document.addEventListener(clickoutEvent, this._hideOnClickOut, this.get('useCapture'));
     }
 
     if (hideOn.indexOf('escapekey') !== -1) {
       this._hideListenersOnDocumentByEvent.keydown = this._hideOnEscapeKey;
-      document.addEventListener('keydown', this._hideOnEscapeKey, true);
+      document.addEventListener('keydown', this._hideOnEscapeKey, this.get('useCapture'));
     }
 
     // Hides the attachment when the mouse leaves the target
     // (or leaves both target and attachment for interactive attachments)
     if (hideOn.indexOf('mouseleave') !== -1) {
       this._hideListenersOnTargetByEvent.mouseleave = this._hideOnMouseLeaveTarget;
-      target.addEventListener('mouseleave', this._hideOnMouseLeaveTarget, true);
+      target.addEventListener('mouseleave', this._hideOnMouseLeaveTarget, this.get('useCapture'));
     }
 
     // Hides the attachment when focus is lost on the target
     ['blur', 'focusout'].forEach((eventType) => {
       if (hideOn.indexOf(eventType) !== -1) {
         this._hideListenersOnTargetByEvent[eventType] = this._hideOnLostFocus;
-        target.addEventListener(eventType, this._hideOnLostFocus, true);
+        target.addEventListener(eventType, this._hideOnLostFocus, this.get('useCapture'));
       }
     });
   },
@@ -558,7 +559,7 @@ export default Component.extend({
       //   queue another fire at the end of the debounce period
       if (!this._hideListenersOnDocumentByEvent.mousemove) {
         this._hideListenersOnDocumentByEvent.mousemove = this._hideIfMouseOutsideTargetOrAttachment;
-        document.addEventListener('mousemove', this._hideIfMouseOutsideTargetOrAttachment, true);
+        document.addEventListener('mousemove', this._hideIfMouseOutsideTargetOrAttachment, this.get('useCapture'));
       }
     } else {
       this._hideAfterDelay();
@@ -578,7 +579,7 @@ export default Component.extend({
       && !this._popperElement.contains(event.target)) {
       // Remove this listener before hiding the attachment
       delete this._hideListenersOnDocumentByEvent.mousemove;
-      document.removeEventListener('mousemove', this._hideIfMouseOutsideTargetOrAttachment, true);
+      document.removeEventListener('mousemove', this._hideIfMouseOutsideTargetOrAttachment, this.get('useCapture'));
 
       this._hideAfterDelay();
     }
@@ -663,7 +664,7 @@ export default Component.extend({
 
   _removeListenersForHideEvents() {
     Object.keys(this._hideListenersOnDocumentByEvent).forEach((eventType) => {
-      document.removeEventListener(eventType, this._hideListenersOnDocumentByEvent[eventType], true);
+      document.removeEventListener(eventType, this._hideListenersOnDocumentByEvent[eventType], this.get('useCapture'));
       delete this._hideListenersOnDocumentByEvent[eventType];
     });
 
@@ -680,19 +681,19 @@ export default Component.extend({
       const hideOnClickListener = this._hideListenersOnTargetByEvent.click;
 
       if (hideOnClickListener) {
-        target.removeEventListener('click', hideOnClickListener, true);
+        target.removeEventListener('click', hideOnClickListener, this.get('useCapture'));
         delete this._hideListenersOnTargetByEvent.click;
       }
 
       this._showListenersOnTargetByEvent.click = this._showAfterDelay;
-      target.addEventListener('click', this._showAfterDelay, true);
+      target.addEventListener('click', this._showAfterDelay, this.get('useCapture'));
     }
 
     ['blur', 'focusout', 'mouseleave'].forEach((eventType) => {
       const listener = this._hideListenersOnTargetByEvent[eventType];
 
       if (listener) {
-        target.removeEventListener(eventType, listener, true);
+        target.removeEventListener(eventType, listener, this.get('useCapture'));
         delete this._hideListenersOnTargetByEvent[eventType];
       }
     });

--- a/addon/defaults.js
+++ b/addon/defaults.js
@@ -19,5 +19,6 @@ export default {
   showDuration: 300,
   showOn: 'mouseenter focus',
   style: null,
-  tooltipClass: 'ember-attacher-popper ember-attacher-tooltip'
+  tooltipClass: 'ember-attacher-popper ember-attacher-tooltip',
+  useCapture: false
 };

--- a/tests/dummy/app/services/popover-data.js
+++ b/tests/dummy/app/services/popover-data.js
@@ -13,5 +13,6 @@ export default Service.extend({
   renderInPlace: false,
   showDelay: 0,
   showDuration: 300,
-  showOn: 'click'
+  showOn: 'click',
+  useCapture: false
 });

--- a/tests/dummy/app/services/tooltip-data.js
+++ b/tests/dummy/app/services/tooltip-data.js
@@ -13,5 +13,6 @@ export default Service.extend({
   renderInPlace: false,
   showDelay: 0,
   showDuration: 300,
-  showOn: 'mouseenter focus'
+  showOn: 'mouseenter focus',
+  useCapture: false
 });


### PR DESCRIPTION
This PR adds a `useCapture` option that causes event handlers in `attach-popover.js` to run in the capturing phase rather than the bubbling phase. It is disabled by default, so the new behavior is opt-in.

The motivation is to work around problems where `hideOn: click/clickout` doesn't work when event propagation is stopped. E.g. when the user clicks out, but the clicked target stops event propagation. In this case the popover won't be hidden when ember-attacher's event handlers are added in the bubbling phase.

Similarly for `hideOn: click`, where an element inside the popover may prevent the intended hide-on-click behavior by stopping propagation in the bubbling phase.