### PR TITLE
Hide in case target is already defined

### DIFF
--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -573,7 +573,7 @@ export default Component.extend({
     const target = this._currentTarget;
 
     // If cursor is not on the attachment or target, hide the popover
-    if (!target.contains(event.target)
+    if (target && !target.contains(event.target)
       && !(this.get('isOffset') && this._isCursorBetweenTargetAndAttachment(event))
       && !this._popperElement.contains(event.target)) {
       // Remove this listener before hiding the attachment


### PR DESCRIPTION
In my project I am getting following exception very often:

```
window TypeError: Cannot read property 'contains' of undefined
    at Class._hideIfMouseOutsideTargetOrAttachment (http://localhost:5001/ui/assets/vendor.js:207018:144)
```
This little change should prevent it.