### PR TITLE
fix(lazyRender and isShown set manually) (#176)

### DIFF
--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -418,6 +418,8 @@ export default Component.extend({
       return;
     }
 
+    this.set('_mustRender', true);
+
     // Make the attachment visible immediately so transition animations can take place
     this._setIsVisibleAfterDelay(true, 0);
 

--- a/tests/integration/components/ember-attacher/is-shown-test.js
+++ b/tests/integration/components/ember-attacher/is-shown-test.js
@@ -90,6 +90,54 @@ module('Integration | Component | isShown', function(hooks) {
     assert.equal(isVisible(attachment), false, 'Hidden again');
   });
 
+  test('isShown works with showOn/hideOn set to `null` with lazyRender', async function(assert) {
+    assert.expect(3);
+
+    this.actions.closePopover = () => {
+      this.set('isShown', false);
+    };
+
+    this.actions.openPopover = () => {
+      this.set('isShown', true);
+    };
+
+    this.set('isShown', false);
+
+    this.set('hideOn', null);
+    this.set('showOn', null);
+
+    await render(hbs`
+      <button id="open" {{action 'openPopover'}}>
+        Click me, captain!
+
+        {{#attach-popover id='attachment'
+                          hideOn=hideOn
+                          isShown=isShown
+                          lazyRender=true
+                          showOn=showOn}}
+          isShown w/ hideOn/ShowOn of 'none'
+
+          <button id="close" {{action 'closePopover'}}>
+            Close
+          </button>
+
+        {{/attach-popover}}
+      </button>
+    `);
+
+    assert.equal(find('#attachment'), undefined, 'Not present in DOM');
+
+    await click('#open');
+
+    const attachment = find('#attachment');
+
+    assert.equal(isVisible(attachment), true, 'Now shown');
+
+    await click('#close');
+
+    assert.equal(isVisible(attachment), false, 'Hidden again');
+  });
+
   test('nested attachers open and close as expected', async function(assert) {
     assert.expect(7);
 


### PR DESCRIPTION
If you wanted to manually toggle `isShown` and still have lazyRender this boolean was never set as it was only used in `_showAfterDelay` function.
We need to update it also in `_show` method which is called by the `isShown` observer.

This PR demonstrate and fix this issue. (#176 )