### PR TITLE
Add class to know if popover has arrow

### DIFF
--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -88,10 +88,11 @@ export default Component.extend({
     );
   }),
 
-  _class: computed('class', 'animation', '_isStartingAnimation', function() {
+  _class: computed('class', 'arrow', 'animation', '_isStartingAnimation', function() {
     const showOrHideClass = `ember-attacher-${this.get('_isStartingAnimation') ? 'show' : 'hide'}`;
+    const arrowClass = `ember-attacher-${this.get('arrow') ? 'with' : 'without'}-arrow`;
 
-    return `ember-attacher-${this.get('animation')} ${this.get('class') || ''} ${showOrHideClass}`;
+    return `ember-attacher-${this.get('animation')} ${this.get('class') || ''} ${showOrHideClass} ${arrowClass}`;
   }),
 
   _style: computed('style', '_transitionDuration', function () {


### PR DESCRIPTION
Ok so I need to give you a bit of context on how this PR is important for our product.

We use `ember-attacher` to create such menu:
![2019-11-14-151650_439x362_scrot](https://user-images.githubusercontent.com/1716173/68869890-d2199b80-06f1-11ea-9ad2-2b2527228c8d.png)

By default, `ember-attacher` has 10px spacing between the popover and the target:
![2019-11-14-152625_700x352_scrot](https://user-images.githubusercontent.com/1716173/68870679-2709e180-06f3-11ea-98e3-7dcc462571df.png)

This spacing is the space needed for arrow 

![2019-11-14-153151_660x322_scrot](https://user-images.githubusercontent.com/1716173/68871142-e52d6b00-06f3-11ea-812c-3fdd58f730ad.png)

and is due to this CSS rule

https://github.com/kybishop/ember-attacher/blob/eb86c5fdd23fc32f233cc1d979fa17e7ae4f528a/addon/styles/_mixins.scss#L80

IMHO, `ember-attacher` should not add spacing if arrow are disabled. However, if we don't want to introduce breaking change. The only way is to provide users a CSS class which show if popover has arrow or not. With this PR, we could override the CSS rule to remove the initial spacing.