### PR TITLE
Fix exception when object is destroyed or destroying

### DIFF
--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -499,6 +499,10 @@ export default Component.extend({
       const hideDuration = parseInt(this.get('hideDuration'));
 
       run(() => {
+        if (this.isDestroyed || this.isDestroying) {
+          return;
+        }
+
         this.set('_transitionDuration', hideDuration);
         this.set('_isStartingAnimation', false);
         this._popperElement.setAttribute('aria-hidden', 'true');

--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -458,6 +458,9 @@ export default Component.extend({
         }
 
         run(() => {
+          if (this.isDestroyed || this.isDestroying || !this._currentTarget) {
+            return;
+          }
           // Make the popper element visible now that it has been positioned
           popperElement.style.visibility = '';
           this.set('_transitionDuration', parseInt(this.get('showDuration')));


### PR DESCRIPTION
As `run` is an async function, There is no guarantee that the `attach-popover` still exist. So we need to duplicate the check.