### PR TITLE
Prevent currentTarget is null crashes

### DIFF
--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -344,6 +344,11 @@ export default Component.extend({
   },
 
   _addListenersForShowEvents() {
+
+    if (!this._currentTarget) {
+      return;
+    }
+
     this.get('_showOn').forEach((event) => {
       this._showListenersOnTargetByEvent[event] = this._showAfterDelay;
 
@@ -601,6 +606,10 @@ export default Component.extend({
   _hideIfMouseOutsideTargetOrAttachment(event) {
     const target = this._currentTarget;
 
+    if (!target) {
+      return;
+    }
+
     // If cursor is not on the attachment or target, hide the popover
     if (!target.contains(event.target)
       && !(this.get('isOffset') && this._isCursorBetweenTargetAndAttachment(event))
@@ -614,6 +623,11 @@ export default Component.extend({
   },
 
   _isCursorBetweenTargetAndAttachment(event) {
+
+    if (!this._currentTarget) {
+      return;
+    }
+
     const { clientX, clientY } = event;
 
     const attachmentPosition = this._popperElement.getBoundingClientRect();
@@ -677,6 +691,10 @@ export default Component.extend({
   _hideOnLostFocus(event) {
     if (event.relatedTarget === null) {
       this._hideAfterDelay();
+    }
+    
+    if (!this._currentTarget) {
+      return;
     }
 
     const targetContainsFocus = this._currentTarget.contains(event.relatedTarget);

--- a/addon/components/attach-tooltip.js
+++ b/addon/components/attach-tooltip.js
@@ -20,6 +20,10 @@ export default AttachPopover.extend({
   didInsertElement() {
     this._super(...arguments);
 
+    if (!this._currentTarget) {
+      return;
+    }
+
     this._currentTarget.setAttribute('aria-describedby', this.id);
   },
 


### PR DESCRIPTION
Crashes were happening because this._currenttarget was null and there were no guards on it.

Just added some checks beforehand. 