### PR TITLE
Import `htmlSafe` from '@ember/template' rather than '@ember/string'.

### DIFF
--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -8,7 +8,7 @@ import layout from '../templates/components/attach-popover';
 import { cancel, debounce, later, next, run } from '@ember/runloop';
 import { getOwner } from '@ember/application';
 import { guidFor } from '@ember/object/internals';
-import { htmlSafe, isHTMLSafe } from '@ember/string';
+import { htmlSafe, isHTMLSafe } from '@ember/template';
 import { stripInProduction } from 'ember-attacher/-debug/helpers';
 import { warn } from '@ember/debug';
 import { isEmpty } from '@ember/utils';

--- a/tests/integration/components/attach-tooltip-test.js
+++ b/tests/integration/components/attach-tooltip-test.js
@@ -2,7 +2,7 @@ import QUnit, { module, test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 QUnit.assert.contains = function(actual, expected, message) {
   this.pushResult({


### PR DESCRIPTION
Deprecation id: [ember-string.htmlsafe-ishtmlsafe](https://deprecations.emberjs.com/v3.x/#toc_ember-string-htmlsafe-ishtmlsafe)

Not certain of version compatibility but thought I'd open the PR to see what the CI build does.

Mentioned in #416