### PR TITLE
Remove excess whitespace content

### DIFF
--- a/addon/templates/components/attach-popover.hbs
+++ b/addon/templates/components/attach-popover.hbs
@@ -1,7 +1,7 @@
 {{unbound _parentFinder}}
 
-{{#if (and _currentTarget (or (not lazyRender) _mustRender))}}
-  {{#ember-popper ariaRole=ariaRole
+{{~#if (and _currentTarget (or (not lazyRender) _mustRender))}}
+  {{~#ember-popper ariaRole=ariaRole
                   class="ember-attacher"
                   eventsEnabled=false
                   id=id
@@ -10,7 +10,7 @@
                   popperContainer=popperContainer
                   popperTarget=_currentTarget
                   registerAPI=(action '_registerAPI')
-                  renderInPlace=renderInPlace as |emberPopper|}}
+                  renderInPlace=renderInPlace as |emberPopper|~}}
     <div class="{{_class}}" style="{{_style}}">
       {{yield (hash emberPopper=emberPopper hide=(action 'hide'))}}
 
@@ -21,5 +21,5 @@
         <div x-circle style="{{_circleTransitionDuration}}"></div>
       {{/if}}
     </div>
-  {{/ember-popper}}
-{{/if}}
+  {{~/ember-popper}}
+{{~/if~}}

--- a/tests/integration/components/ember-attacher/ember-attacher-test.js
+++ b/tests/integration/components/ember-attacher/ember-attacher-test.js
@@ -7,6 +7,16 @@ import { render, find } from '@ember/test-helpers';
 module('Integration | Component | ember attacher', function(hooks) {
   setupRenderingTest(hooks);
 
+  test('it leaves no content', async function(assert) {
+    await render(hbs`
+      <div id='wrapper'>{{#attach-popover}}{{/attach-popover}}</div>
+    `);
+
+    const wrapper = find('#wrapper');
+
+    assert.equal(wrapper.textContent, '');
+  });
+
   test('it renders', async function(assert) {
     assert.expect(2);
 


### PR DESCRIPTION
This change removes excess white-space rendered by attacher to it's container. This allows, for example, a button with no white-space around the button text.