### PR TITLE
Updating imports for htmlSafe, isHTMLSafe

### DIFF
--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -8,7 +8,7 @@ import layout from '../templates/components/attach-popover';
 import { cancel, debounce, later, next, run } from '@ember/runloop';
 import { getOwner } from '@ember/application';
 import { guidFor } from '@ember/object/internals';
-import { htmlSafe, isHTMLSafe } from '@ember/string';
+import { htmlSafe, isHTMLSafe } from '@ember/template';
 import { stripInProduction } from 'ember-attacher/-debug/helpers';
 import { warn } from '@ember/debug';
 import { isEmpty } from '@ember/utils';


### PR DESCRIPTION
`htmlSafe` and `isHTMLSafe` have been deprecated from `@ember/string` and moved to `@ember/template` seemingly as of Ember 3.x: https://api.emberjs.com/ember/release/functions/@ember%2Ftemplate/htmlSafe

`ember test` passes but the `ember try:each` target mentioned in the CONTRIBUTING guide doesn't seem to work due to unrelated dependency fetching errors. Please let me know if there's something else I should run.